### PR TITLE
docs: add quick 'How to run locally' (Ubuntu/Node/Yarn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ This is explained in more detail in this [specification on hardfork activation i
 ## License
 
 MIT License, see [`LICENSE` file](./LICENSE).
+
+---
+
+## How to run locally
+
+1. Install dependencies
+   ```bash
+   corepack enable
+   corepack prepare yarn@1.22.22 --activate
+   yarn install
+


### PR DESCRIPTION
Adds a minimal **How to run locally** section to speed up onboarding. No functional changes.