### PR TITLE
ci: fix yamllint installation in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI Basic Checks
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 6 * * *" # daily
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check YAML syntax
+        run: |
+          if command -v yamllint >/dev/null 2>&1; then
+            yamllint .
+          else
+            echo "yamllint not installed; skipping"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,14 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: "0 6 * * *" # daily
+    - cron: "0 6 * * *"
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check YAML syntax
-        run: |
-          if command -v yamllint >/dev/null 2>&1; then
-            yamllint .
-          else
-            echo "yamllint not installed; skipping"
-          fi
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install yamllint
+      - run: yamllint .


### PR DESCRIPTION
Fixes failing CI by installing yamllint before running YAML checks.